### PR TITLE
Initial Elasticsearch module implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
-#  Local .terraform directories
-**/.terraform/*
-
-# .tfstate files
 *.tfstate
-*.tfstate.*
-
-# .tfvars files
+*.tfstate.backup
+.terraform/
+.DS_Store
+.idea/*
 *.tfvars
+*.plan

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
 # aws-terraform-elasticsearch
+
+This module creates an ElasticSearch cluster.
+
+
+## Basic Usage
+
+### Internet accessible endpoint
+```
+module "elasticsearch" {
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.1"
+
+ name          = "titus-test-es-internet-endpoint"
+ ip_whitelist  = ["1.2.3.4"]
+}
+```
+
+### VPC accessible endpoint
+```
+module "elasticsearch" {
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.1"
+
+ name          = "titus-test-es-internet-endpoint"
+ vpc_enabled     = true
+ security_groups = ["${module.sg.public_web_security_group_id}"]
+ subnets         = ["${module.vpc.private_subnets}"]
+}
+```
+
+Full working references are available at [examples](examples)
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| data_node_count | Number of data nodes in the Elasticsearch cluster. | string | `6` | no |
+| data_node_instance_type | Select data node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types. | string | `m4.large.elasticsearch` | no |
+| ebs_iops | The number of I/O operations per second (IOPS) that the volume supports. | string | `0` | no |
+| ebs_size | The size of the EBS volume for each data node. | string | `20` | no |
+| ebs_type | The EBS volume type to use with the Amazon ES domain, such as standard, gp2, or io1. | string | `gp2` | no |
+| elasticsearch_version | Elasticsearch Version. | string | `6.3` | no |
+| encryption_enabled | A boolean value to determine if encryption at rest is enabled for the Elasticsearch cluster. | string | `false` | no |
+| encryption_kms_key | The KMS key to use for encryption at rest on the Elasticsearch cluster.If omitted and encryption at rest is enabled, the aws/es KMS key is used. | string | `` | no |
+| environment | Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test | string | `Development` | no |
+| internal_record_name | Record Name for the new Resource Record in the Internal Hosted Zone. i.e. es | string | `` | no |
+| internal_zone_name | TLD for Internal Hosted Zone. i.e. mycompany.local | string | `` | no |
+| ip_whitelist | IP Addresses allowed to access the ElasticSearch Cluster.  Should be supplied if Elasticsearch cluster is not VPC enabled. | list | `<list>` | no |
+| logging_application_logs | A boolean value to determine if logging is enabled for ES_APPLICATION_LOGS. | string | `false` | no |
+| logging_index_slow_logs | A boolean value to determine if logging is enabled for INDEX_SLOW_LOGS. | string | `false` | no |
+| logging_retention | The number of days to retain Cloudwatch Logs for the Elasticsearch cluster. | string | `30` | no |
+| logging_search_slow_logs | A boolean value to determine if logging is enabled for SEARCH_SLOW_LOGS. | string | `false` | no |
+| master_node_count | Number of master nodes in the Elasticsearch cluster.  Allowed values are 3 or 5. | string | `3` | no |
+| master_node_instance_type | Select master node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types. | string | `m4.large.elasticsearch` | no |
+| name | The desired name for the Elasticsearch domain. | string | - | yes |
+| security_groups | A list of EC2 security groups to assign to the Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled. | list | `<list>` | no |
+| snapshot_start_hour | The hour (0-23) to issue a daily snapshot of Elasticsearch cluster. | string | `0` | no |
+| subnets | Subnets for Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled. | list | `<list>` | no |
+| tags | Additional tags to be added to the Elasticsearch cluster. | map | `<map>` | no |
+| vpc_enabled | A boolean value to determine if the Elasticsearch cluster is VPC enabled. | string | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| arn | The ARN for the Elasticsearch cluster |
+| endpoint | The endpoint for the Elasticsearch cluster |
+| kibana_endpoint | The kibana endpoint for the Elasticsearch cluster |
+| log_group_arn | The ARN for the CloudWatch Log group for this Elasticsearch Cluster |
+

--- a/examples/basic_internet_endpoint.tf
+++ b/examples/basic_internet_endpoint.tf
@@ -1,0 +1,10 @@
+####################################################
+# Basic Internet accessible Elasticsearch endpoint #
+####################################################
+
+module "es_internet" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.1"
+
+  name         = "es-internet-endpoint"
+  ip_whitelist = ["1.2.3.4"]
+}

--- a/examples/basic_vpc_endpoint.tf
+++ b/examples/basic_vpc_endpoint.tf
@@ -1,0 +1,26 @@
+###############################################
+# Basic VPC accessible Elasticsearch endpoint #
+###############################################
+
+module "vpc" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.1"
+
+  vpc_name = "Test1VPC"
+}
+
+module "sg" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group//?ref=v0.0.4"
+
+  resource_name = "Test-SG"
+  vpc_id        = "${module.vpc.vpc_id}"
+}
+
+module "es_vpc" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.1"
+
+  name = "es-vpc-endpoint"
+
+  vpc_enabled     = true
+  security_groups = ["${module.sg.public_web_security_group_id}"]
+  subnets         = ["${module.vpc.private_subnets}"]
+}

--- a/examples/full_example.tf
+++ b/examples/full_example.tf
@@ -1,0 +1,51 @@
+#########################################################
+# Customized Internet accessible Elasticsearch endpoint #
+#########################################################
+
+data "aws_kms_alias" "es_kms" {
+  name = "alias/aws/es"
+}
+
+module "internal_zone" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v.0.0.1"
+
+  zone_name     = "mycompany.local"
+  environment   = "Development"
+  target_vpc_id = "${module.vpc.vpc_id}"
+}
+
+module "es_all_options" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.1"
+
+  name = "es-custom"
+
+  ip_whitelist = ["1.2.3.4"]
+
+  elasticsearch_version = "6.2"
+  environment           = "Production"
+
+  data_node_count           = "8"
+  data_node_instance_type   = "r4.large.elasticsearch"
+  master_node_count         = "5"
+  master_node_instance_type = "r4.large.elasticsearch"
+
+  encryption_enabled = true
+  encryption_kms_key = "${data.aws_kms_alias.es_kms.target_key_arn}"
+
+  ebs_iops = "1000"
+  ebs_size = "50"
+  ebs_type = "io1"
+
+  internal_record_name = "es-custom"
+  internal_zone_name   = "${module.internal_zone.internal_hosted_name}"
+
+  logging_application_logs = true
+  logging_index_slow_logs  = true
+  logging_retention        = 14
+  logging_search_slow_logs = true
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,189 @@
+/**
+ * # aws-terraform-elasticsearch
+ *
+ *This module creates an ElasticSearch cluster.
+ *
+ *
+ *## Basic Usage
+ *
+ ### Internet accessible endpoint
+ *```
+ *module "elasticsearch" {
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.1"
+ *
+ *  name          = "titus-test-es-internet-endpoint"
+ *  ip_whitelist  = ["1.2.3.4"]
+ *}
+ *```
+ *
+ ### VPC accessible endpoint
+ *```
+ *module "elasticsearch" {
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.1"
+ *
+ *  name          = "titus-test-es-internet-endpoint"
+ *  vpc_enabled     = true
+ *  security_groups = ["${module.sg.public_web_security_group_id}"]
+ *  subnets         = ["${module.vpc.private_subnets}"]
+ *}
+ *```
+ *
+ * Full working references are available at [examples](examples)
+ */
+
+locals {
+  tags {
+    Name            = "${var.name}"
+    ServiceProvider = "Rackspace"
+    Environment     = "${var.environment}"
+  }
+
+  policy_condition = {
+    standard = [
+      {
+        test     = "IpAddress"
+        variable = "aws:SourceIp"
+        values   = ["${var.ip_whitelist}"]
+      },
+    ]
+
+    vpc = []
+  }
+
+  vpc_configuration = {
+    standard = []
+
+    vpc = [
+      {
+        security_group_ids = ["${var.security_groups}"]
+        subnet_ids         = ["${var.subnets}"]
+      },
+    ]
+  }
+
+  vpc_lookup     = "${var.vpc_enabled ? "vpc" : "standard"}"
+  enable_logging = "${var.logging_application_logs || var.logging_index_slow_logs || var.logging_search_slow_logs}"
+}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    actions   = ["es:*"]
+    effect    = "Allow"
+    resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.name}/*"]
+
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+
+    condition = "${local.policy_condition[local.vpc_lookup]}"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "es" {
+  count = "${local.enable_logging ? 1 : 0}"
+
+  name_prefix       = "${var.name}"
+  retention_in_days = "${var.logging_retention}"
+  tags              = "${merge(var.tags, local.tags)}"
+}
+
+data "aws_iam_policy_document" "es_cloudwatch_policy" {
+  count = "${local.enable_logging ? 1 : 0}"
+
+  statement {
+    actions   = ["logs:PutLogEvents", "logs:CreateLogStream"]
+    effect    = "Allow"
+    resources = ["${element(concat(aws_cloudwatch_log_group.es.*.arn, list("*")), 0)}"]
+
+    principals {
+      identifiers = ["es.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "es_cloudwatch_policy" {
+  count = "${local.enable_logging ? 1 : 0}"
+
+  policy_document = "${element(data.aws_iam_policy_document.es_cloudwatch_policy.*.json, 0)}"
+  policy_name     = "Elasticsearch-Log-Access"
+}
+
+resource "aws_elasticsearch_domain" "es" {
+  access_policies = "${data.aws_iam_policy_document.policy.json}"
+
+  advanced_options = [{
+    "rest.action.multi.allow_explicit_index" = "true"
+  }]
+
+  domain_name           = "${lower(var.name)}"
+  elasticsearch_version = "${var.elasticsearch_version}"
+
+  snapshot_options = {
+    automated_snapshot_start_hour = "${var.snapshot_start_hour}"
+  }
+
+  tags        = "${merge(var.tags, local.tags)}"
+  vpc_options = ["${local.vpc_configuration[local.vpc_lookup]}"]
+
+  cluster_config {
+    dedicated_master_count   = "${var.master_node_count > 0 ? var.master_node_count : ""}"
+    dedicated_master_enabled = "${var.master_node_count > 0}"
+    dedicated_master_type    = "${var.master_node_count > 0 ? var.master_node_instance_type : ""}"
+    instance_count           = "${var.data_node_count}"
+    instance_type            = "${var.data_node_instance_type}"
+    zone_awareness_enabled   = true
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    iops        = "${lower(var.ebs_type) == "io1" ? var.ebs_iops : 0}"
+    volume_size = "${var.ebs_size}"
+    volume_type = "${lower(var.ebs_type)}"
+  }
+
+  encrypt_at_rest {
+    enabled    = "${var.encryption_enabled}"
+    kms_key_id = "${var.encryption_kms_key}"
+  }
+
+  log_publishing_options = [
+    {
+      log_type                 = "INDEX_SLOW_LOGS"
+      cloudwatch_log_group_arn = "${element(concat(aws_cloudwatch_log_group.es.*.arn, list("")), 0)}"
+      enabled                  = "${var.logging_index_slow_logs}"
+    },
+    {
+      log_type                 = "SEARCH_SLOW_LOGS"
+      cloudwatch_log_group_arn = "${element(concat(aws_cloudwatch_log_group.es.*.arn, list("")), 0)}"
+      enabled                  = "${var.logging_search_slow_logs}"
+    },
+    {
+      log_type                 = "ES_APPLICATION_LOGS"
+      cloudwatch_log_group_arn = "${element(concat(aws_cloudwatch_log_group.es.*.arn, list("")), 0)}"
+      enabled                  = "${var.logging_application_logs}"
+    },
+  ]
+}
+
+data "aws_route53_zone" "hosted_zone" {
+  count = "${var.internal_record_name != "" ? 1 : 0}"
+
+  name         = "${var.internal_zone_name}"
+  private_zone = true
+}
+
+resource "aws_route53_record" "zone_record_alias" {
+  count = "${var.internal_record_name != "" ? 1 : 0}"
+
+  name    = "${var.internal_record_name}.${data.aws_route53_zone.hosted_zone.name}"
+  records = ["${aws_elasticsearch_domain.es.endpoint}"]
+  ttl     = "300"
+  type    = "CNAME"
+  zone_id = "${data.aws_route53_zone.hosted_zone.zone_id}"
+}

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,19 @@
+output "arn" {
+  description = "The ARN for the Elasticsearch cluster"
+  value       = "${aws_elasticsearch_domain.es.arn}"
+}
+
+output "log_group_arn" {
+  description = "The ARN for the CloudWatch Log group for this Elasticsearch Cluster"
+  value       = "${aws_cloudwatch_log_group.es.*.arn}"
+}
+
+output "endpoint" {
+  description = "The endpoint for the Elasticsearch cluster"
+  value       = "${aws_elasticsearch_domain.es.endpoint}"
+}
+
+output "kibana_endpoint" {
+  description = "The kibana endpoint for the Elasticsearch cluster"
+  value       = "${aws_elasticsearch_domain.es.kibana_endpoint}"
+}

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -1,0 +1,94 @@
+provider "aws" {
+  version = "~> 1.2"
+  region  = "us-west-2"
+}
+
+####################################################
+# Basic Internet accessible Elasticsearch endpoint #
+####################################################
+
+module "es_internet" {
+  source = "../../module"
+
+  name         = "es-internet-endpoint"
+  ip_whitelist = ["1.2.3.4"]
+}
+
+###############################################
+# Basic VPC accessible Elasticsearch endpoint #
+###############################################
+
+module "vpc" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//"
+
+  vpc_name = "Test1VPC"
+}
+
+module "sg" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group//"
+
+  resource_name = "Test-SG"
+  vpc_id        = "${module.vpc.vpc_id}"
+}
+
+module "es_vpc" {
+  source = "../../module"
+
+  name = "es-vpc-endpoint"
+
+  vpc_enabled     = true
+  security_groups = ["${module.sg.public_web_security_group_id}"]
+  subnets         = ["${module.vpc.private_subnets}"]
+}
+
+#########################################################
+# Customized Internet accessible Elasticsearch endpoint #
+#########################################################
+
+data "aws_kms_alias" "es_kms" {
+  name = "alias/aws/es"
+}
+
+module "internal_zone" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//"
+
+  zone_name     = "mycompany.local"
+  environment   = "Development"
+  target_vpc_id = "${module.vpc.vpc_id}"
+}
+
+module "es_all_options" {
+  source = "../../module"
+
+  name = "es-custom"
+
+  ip_whitelist = ["1.2.3.4"]
+
+  elasticsearch_version = "6.2"
+  environment           = "Production"
+
+  data_node_count           = "8"
+  data_node_instance_type   = "r4.large.elasticsearch"
+  master_node_count         = "5"
+  master_node_instance_type = "r4.large.elasticsearch"
+
+  encryption_enabled = true
+  encryption_kms_key = "${data.aws_kms_alias.es_kms.target_key_arn}"
+
+  ebs_iops = "1000"
+  ebs_size = "50"
+  ebs_type = "io1"
+
+  internal_record_name = "es-custom"
+  internal_zone_name   = "${module.internal_zone.internal_hosted_name}"
+
+  logging_application_logs = true
+  logging_index_slow_logs  = true
+  logging_retention        = 14
+  logging_search_slow_logs = true
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,142 @@
+variable "name" {
+  description = "The desired name for the Elasticsearch domain."
+  type        = "string"
+}
+
+variable "data_node_count" {
+  description = "Number of data nodes in the Elasticsearch cluster."
+  type        = "string"
+  default     = 6
+}
+
+variable "data_node_instance_type" {
+  description = "Select data node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types."
+  type        = "string"
+  default     = "m4.large.elasticsearch"
+}
+
+variable "ebs_iops" {
+  description = "The number of I/O operations per second (IOPS) that the volume supports."
+  type        = "string"
+  default     = 0
+}
+
+variable "ebs_size" {
+  description = "The size of the EBS volume for each data node."
+  type        = "string"
+  default     = 20
+}
+
+variable "ebs_type" {
+  description = "The EBS volume type to use with the Amazon ES domain, such as standard, gp2, or io1."
+  type        = "string"
+  default     = "gp2"
+}
+
+variable "elasticsearch_version" {
+  description = "Elasticsearch Version."
+  type        = "string"
+  default     = "6.3"
+}
+
+variable "encryption_enabled" {
+  description = "A boolean value to determine if encryption at rest is enabled for the Elasticsearch cluster."
+  type        = "string"
+  default     = false
+}
+
+variable "encryption_kms_key" {
+  description = "The KMS key to use for encryption at rest on the Elasticsearch cluster.If omitted and encryption at rest is enabled, the aws/es KMS key is used."
+  type        = "string"
+  default     = ""
+}
+
+variable "environment" {
+  description = "Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test"
+  type        = "string"
+  default     = "Development"
+}
+
+variable "internal_record_name" {
+  description = "Record Name for the new Resource Record in the Internal Hosted Zone. i.e. es"
+  type        = "string"
+  default     = ""
+}
+
+variable "internal_zone_name" {
+  description = "TLD for Internal Hosted Zone. i.e. mycompany.local"
+  type        = "string"
+  default     = ""
+}
+
+variable "ip_whitelist" {
+  description = "IP Addresses allowed to access the ElasticSearch Cluster.  Should be supplied if Elasticsearch cluster is not VPC enabled."
+  type        = "list"
+  default     = ["127.0.0.1"]
+}
+
+variable "logging_application_logs" {
+  description = "A boolean value to determine if logging is enabled for ES_APPLICATION_LOGS."
+  type        = "string"
+  default     = false
+}
+
+variable "logging_index_slow_logs" {
+  description = "A boolean value to determine if logging is enabled for INDEX_SLOW_LOGS."
+  type        = "string"
+  default     = false
+}
+
+variable "logging_retention" {
+  description = "The number of days to retain Cloudwatch Logs for the Elasticsearch cluster."
+  type        = "string"
+  default     = "30"
+}
+
+variable "logging_search_slow_logs" {
+  description = "A boolean value to determine if logging is enabled for SEARCH_SLOW_LOGS."
+  type        = "string"
+  default     = false
+}
+
+variable "master_node_count" {
+  description = "Number of master nodes in the Elasticsearch cluster.  Allowed values are 3 or 5."
+  type        = "string"
+  default     = 3
+}
+
+variable "master_node_instance_type" {
+  description = "Select master node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types."
+  type        = "string"
+  default     = "m4.large.elasticsearch"
+}
+
+variable "security_groups" {
+  description = "A list of EC2 security groups to assign to the Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled."
+  type        = "list"
+  default     = []
+}
+
+variable snapshot_start_hour {
+  description = "The hour (0-23) to issue a daily snapshot of Elasticsearch cluster."
+  type        = "string"
+  default     = 0
+}
+
+variable "subnets" {
+  description = "Subnets for Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled."
+  type        = "list"
+  default     = []
+}
+
+variable "tags" {
+  description = "Additional tags to be added to the Elasticsearch cluster."
+  type        = "map"
+  default     = {}
+}
+
+variable "vpc_enabled" {
+  description = "A boolean value to determine if the Elasticsearch cluster is VPC enabled."
+  type        = "string"
+  default     = false
+}


### PR DESCRIPTION
Implement an Elasticsearch module with all features of the current CloudFormation Elasticsearch template.

Adds capability for encryption at rest and exporting of supported ES logs to CloudWatch Logs.

Fixes rackspace-infrastructure-automation/aws-terraform-internal#33