### PR TITLE
Allow no dedicated master in ES domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Full working references are available at [examples](examples)
 | logging_index_slow_logs | A boolean value to determine if logging is enabled for INDEX_SLOW_LOGS. | string | `false` | no |
 | logging_retention | The number of days to retain Cloudwatch Logs for the Elasticsearch cluster. | string | `30` | no |
 | logging_search_slow_logs | A boolean value to determine if logging is enabled for SEARCH_SLOW_LOGS. | string | `false` | no |
-| master_node_count | Number of master nodes in the Elasticsearch cluster.  Allowed values are 3 or 5. | string | `3` | no |
+| master_node_count | Number of master nodes in the Elasticsearch cluster.  Allowed values are 0, 3 or 5. | string | `0` | no |
 | master_node_instance_type | Select master node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types. | string | `m4.large.elasticsearch` | no |
 | name | The desired name for the Elasticsearch domain. | string | - | yes |
 | security_groups | A list of EC2 security groups to assign to the Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled. | list | `<list>` | no |
@@ -67,4 +67,3 @@ Full working references are available at [examples](examples)
 | endpoint | The endpoint for the Elasticsearch cluster |
 | kibana_endpoint | The kibana endpoint for the Elasticsearch cluster |
 | log_group_arn | The ARN for the CloudWatch Log group for this Elasticsearch Cluster |
-

--- a/main.tf
+++ b/main.tf
@@ -132,9 +132,9 @@ resource "aws_elasticsearch_domain" "es" {
   vpc_options = ["${local.vpc_configuration[local.vpc_lookup]}"]
 
   cluster_config {
-    dedicated_master_count   = "${var.master_node_count > 0 ? var.master_node_count : ""}"
+    dedicated_master_count   = "${var.master_node_count > 0 ? var.master_node_count : 0 }"
     dedicated_master_enabled = "${var.master_node_count > 0}"
-    dedicated_master_type    = "${var.master_node_count > 0 ? var.master_node_instance_type : ""}"
+    dedicated_master_type    = "${var.master_node_count > 0 ? var.master_node_instance_type : "" }"
     instance_count           = "${var.data_node_count}"
     instance_type            = "${var.data_node_instance_type}"
     zone_awareness_enabled   = true

--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable "logging_search_slow_logs" {
 variable "master_node_count" {
   description = "Number of master nodes in the Elasticsearch cluster.  Allowed values are 0, 3 or 5."
   type        = "string"
-  default     = 0
+  default     = 3
 }
 
 variable "master_node_instance_type" {
@@ -117,7 +117,7 @@ variable "security_groups" {
   default     = []
 }
 
-variable snapshot_start_hour {
+variable "snapshot_start_hour" {
   description = "The hour (0-23) to issue a daily snapshot of Elasticsearch cluster."
   type        = "string"
   default     = 0

--- a/variables.tf
+++ b/variables.tf
@@ -100,9 +100,9 @@ variable "logging_search_slow_logs" {
 }
 
 variable "master_node_count" {
-  description = "Number of master nodes in the Elasticsearch cluster.  Allowed values are 3 or 5."
+  description = "Number of master nodes in the Elasticsearch cluster.  Allowed values are 0, 3 or 5."
   type        = "string"
-  default     = 3
+  default     = 0
 }
 
 variable "master_node_instance_type" {


### PR DESCRIPTION
You can create ES with no dedicated masters. Current module does not allow for this by saying that if `master_node_count` is not > 0 then the provided answer to the ES call is an empty string which does not satisfy the constraint of the service.

Change here makes the default behaviour to be no dedicated master.