### PR TITLE
Parameterise Zone Awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Full working references are available at [examples](examples)
 | logging_index_slow_logs | A boolean value to determine if logging is enabled for INDEX_SLOW_LOGS. | string | `false` | no |
 | logging_retention | The number of days to retain Cloudwatch Logs for the Elasticsearch cluster. | string | `30` | no |
 | logging_search_slow_logs | A boolean value to determine if logging is enabled for SEARCH_SLOW_LOGS. | string | `false` | no |
-| master_node_count | Number of master nodes in the Elasticsearch cluster.  Allowed values are 0, 3 or 5. | string | `0` | no |
+| master_node_count | Number of master nodes in the Elasticsearch cluster.  Allowed values are 0, 3 or 5. | string | `3` | no |
 | master_node_instance_type | Select master node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types. | string | `m4.large.elasticsearch` | no |
 | name | The desired name for the Elasticsearch domain. | string | - | yes |
 | security_groups | A list of EC2 security groups to assign to the Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled. | list | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Full working references are available at [examples](examples)
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| data_node_count | Number of data nodes in the Elasticsearch cluster. | string | `6` | no |
+| data_node_count | Number of data nodes in the Elasticsearch cluster. If using Zone Awareness this must be an even number. | string | `6` | no |
 | data_node_instance_type | Select data node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types. | string | `m4.large.elasticsearch` | no |
 | ebs_iops | The number of I/O operations per second (IOPS) that the volume supports. | string | `0` | no |
 | ebs_size | The size of the EBS volume for each data node. | string | `20` | no |
@@ -54,7 +54,7 @@ Full working references are available at [examples](examples)
 | name | The desired name for the Elasticsearch domain. | string | - | yes |
 | security_groups | A list of EC2 security groups to assign to the Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled. | list | `<list>` | no |
 | snapshot_start_hour | The hour (0-23) to issue a daily snapshot of Elasticsearch cluster. | string | `0` | no |
-| subnets | Subnets for Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled. | list | `<list>` | no |
+| subnets | Subnets for Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled. If not using Zone Awareness this should be a list of one subnet. | list | `<list>` | no |
 | tags | Additional tags to be added to the Elasticsearch cluster. | map | `<map>` | no |
 | vpc_enabled | A boolean value to determine if the Elasticsearch cluster is VPC enabled. | string | `false` | no |
 | zone_awareness_enabled | A boolean value to determine if Zone Awareness is enabled. The number of data nodes must be even if this is `true`. | string | `true` | no |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ module "elasticsearch" {
 
 Full working references are available at [examples](examples)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -58,6 +57,7 @@ Full working references are available at [examples](examples)
 | subnets | Subnets for Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled. | list | `<list>` | no |
 | tags | Additional tags to be added to the Elasticsearch cluster. | map | `<map>` | no |
 | vpc_enabled | A boolean value to determine if the Elasticsearch cluster is VPC enabled. | string | `false` | no |
+| zone_awareness_enabled | A boolean value to determine if Zone Awareness is enabled. The number of data nodes must be even if this is `true`. | string | `true` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ resource "aws_elasticsearch_domain" "es" {
     dedicated_master_type    = "${var.master_node_count > 0 ? var.master_node_instance_type : "" }"
     instance_count           = "${var.data_node_count}"
     instance_type            = "${var.data_node_instance_type}"
-    zone_awareness_enabled   = true
+    zone_awareness_enabled   = "${var.zone_awareness_enabled}"
   }
 
   ebs_options {

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "name" {
 }
 
 variable "data_node_count" {
-  description = "Number of data nodes in the Elasticsearch cluster."
+  description = "Number of data nodes in the Elasticsearch cluster. If using Zone Awareness this must be an even number."
   type        = "string"
   default     = 6
 }
@@ -124,7 +124,7 @@ variable "snapshot_start_hour" {
 }
 
 variable "subnets" {
-  description = "Subnets for Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled."
+  description = "Subnets for Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled. If not using Zone Awareness this should be a list of one subnet."
   type        = "list"
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -140,3 +140,9 @@ variable "vpc_enabled" {
   type        = "string"
   default     = false
 }
+
+variable "zone_awareness_enabled" {
+  description = "A boolean value to determine if Zone Awareness is enabled. The number of data nodes must be even if this is `true`."
+  type        = "string"
+  default     = "true"
+}


### PR DESCRIPTION
Zone awareness was forced to true which meant you were forced into providing an even number of data nodes. Some customers want a single node for non production environments so added a new variable and updated some other variables to reference this.