### PR TITLE
Add support for creating ElasticSearch Service Linked Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This module creates an ElasticSearch cluster.
 ### Internet accessible endpoint
 ```
 module "elasticsearch" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.1"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.4"
 
- name          = "titus-test-es-internet-endpoint"
+ name          = "es-internet-endpoint"
  ip_whitelist  = ["1.2.3.4"]
 }
 ```
@@ -17,9 +17,9 @@ module "elasticsearch" {
 ### VPC accessible endpoint
 ```
 module "elasticsearch" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.1"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.4"
 
- name          = "titus-test-es-internet-endpoint"
+ name          = "es-vpc-endpoint"
  vpc_enabled     = true
  security_groups = ["${module.sg.public_web_security_group_id}"]
  subnets         = ["${module.vpc.private_subnets}"]
@@ -28,10 +28,23 @@ module "elasticsearch" {
 
 Full working references are available at [examples](examples)
 
+## Limitation
+Terraform does not create the IAM Service Linked Role for ElasticSearch automatically.  If this role is not present on an account, the `create_service_linked_role` parameter should be set to true for the first ElasticSearch instance.  This will create the required role.  This option should not be set to true on more than a single deployment per account, or it will result in a naming conflict.  If the role is not present an error similar to the following would result:
+
+```
+1 error(s) occurred:
+
+* module.elasticsearch.aws_elasticsearch_domain.es: 1 error(s) occurred:
+
+* aws_elasticsearch_domain.es: Error reading IAM Role AWSServiceRoleForAmazonElasticsearchService: NoSuchEntity: The role with name AWSServiceRoleForAmazonElasticsearchService cannot be found.
+   status code: 404, request id: 5a1614d2-1e64-11e9-a87e-3149d48d2026
+```
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| create\_service\_linked\_role | A boolean value to determine if the ElasticSearch Service Linked Role should be created.  This should only be set to true if the Service Linked Role is not already present. | string | `"false"` | no |
 | data\_node\_count | Number of data nodes in the Elasticsearch cluster. If using Zone Awareness this must be an even number. | string | `"6"` | no |
 | data\_node\_instance\_type | Select data node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types. | string | `"m4.large.elasticsearch"` | no |
 | ebs\_iops | The number of I/O operations per second (IOPS) that the volume supports. | string | `"0"` | no |

--- a/examples/basic_internet_endpoint.tf
+++ b/examples/basic_internet_endpoint.tf
@@ -3,7 +3,7 @@
 ####################################################
 
 module "es_internet" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.4"
 
   name         = "es-internet-endpoint"
   ip_whitelist = ["1.2.3.4"]

--- a/examples/basic_vpc_endpoint.tf
+++ b/examples/basic_vpc_endpoint.tf
@@ -16,7 +16,7 @@ module "sg" {
 }
 
 module "es_vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.4"
 
   name = "es-vpc-endpoint"
 

--- a/examples/full_example.tf
+++ b/examples/full_example.tf
@@ -15,7 +15,7 @@ module "internal_zone" {
 }
 
 module "es_all_options" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.4"
 
   name = "es-custom"
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "name" {
   type        = "string"
 }
 
+variable "create_service_linked_role" {
+  description = "A boolean value to determine if the ElasticSearch Service Linked Role should be created.  This should only be set to true if the Service Linked Role is not already present."
+  type        = "string"
+  default     = false
+}
+
 variable "data_node_count" {
   description = "Number of data nodes in the Elasticsearch cluster. If using Zone Awareness this must be an even number."
   type        = "string"


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/207
##### Summary of change(s):

- Adds `create_service_linked_role` variable and optional `aws_iam_service_linked_role` resource.  Resource is required in cases where the role is not already present on the AWS account.
- Adds section to readme to detail when and why the `create_service_linked_role` parameter should be enabled.
- Forces dependency on 

the SLR to prevent issues when creating the ElasticSearch domain.
##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Yes, readme has been updated.
##### Do examples need to be updated based on changes?
No, change is straightforward, and section added to readme outlining use.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.