### PR TITLE
Move from data internal zone object to all vars being supplied

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,33 @@ This module creates an ElasticSearch cluster.
 ## Basic Usage
 
 ### Internet accessible endpoint
-```
-module "elasticsearch" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.4"
 
- name          = "es-internet-endpoint"
- ip_whitelist  = ["1.2.3.4"]
+```HCL
+module "elasticsearch" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.5"
+
+  name          = "es-internet-endpoint"
+  ip_whitelist  = ["1.2.3.4"]
 }
 ```
 
 ### VPC accessible endpoint
-```
-module "elasticsearch" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.4"
 
- name          = "es-vpc-endpoint"
- vpc_enabled     = true
- security_groups = ["${module.sg.public_web_security_group_id}"]
- subnets         = ["${module.vpc.private_subnets}"]
+```HCL
+module "elasticsearch" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.5"
+
+  name            = "es-vpc-endpoint"
+  vpc_enabled     = true
+  security_groups = ["${module.sg.public_web_security_group_id}"]
+  subnets         = ["${module.vpc.private_subnets}"]
 }
 ```
 
 Full working references are available at [examples](examples)
 
 ## Limitation
+
 Terraform does not create the IAM Service Linked Role for ElasticSearch automatically.  If this role is not present on an account, the `create_service_linked_role` parameter should be set to true for the first ElasticSearch instance.  This will create the required role.  This option should not be set to true on more than a single deployment per account, or it will result in a naming conflict.  If the role is not present an error similar to the following would result:
 
 ```
@@ -37,7 +40,7 @@ Terraform does not create the IAM Service Linked Role for ElasticSearch automati
 * module.elasticsearch.aws_elasticsearch_domain.es: 1 error(s) occurred:
 
 * aws_elasticsearch_domain.es: Error reading IAM Role AWSServiceRoleForAmazonElasticsearchService: NoSuchEntity: The role with name AWSServiceRoleForAmazonElasticsearchService cannot be found.
-   status code: 404, request id: 5a1614d2-1e64-11e9-a87e-3149d48d2026
+    status code: 404, request id: 5a1614d2-1e64-11e9-a87e-3149d48d2026
 ```
 
 ## Inputs
@@ -54,8 +57,9 @@ Terraform does not create the IAM Service Linked Role for ElasticSearch automati
 | encryption\_enabled | A boolean value to determine if encryption at rest is enabled for the Elasticsearch cluster. | string | `"false"` | no |
 | encryption\_kms\_key | The KMS key to use for encryption at rest on the Elasticsearch cluster.If omitted and encryption at rest is enabled, the aws/es KMS key is used. | string | `""` | no |
 | environment | Application environment for which this network is being created. Preferred value are Development, Integration, PreProduction, Production, QA, Staging, or Test | string | `"Development"` | no |
-| internal\_record\_name | Record Name for the new Resource Record in the Internal Hosted Zone. i.e. es | string | `""` | no |
-| internal\_zone\_name | TLD for Internal Hosted Zone. i.e. mycompany.local | string | `""` | no |
+| internal\_record\_name | Record Name for the new Resource Record in the Internal Hosted Zone | string | `""` | no |
+| internal\_zone\_id | The Route53 Internal Hosted Zone ID | string | `""` | no |
+| internal\_zone\_name | TLD for Internal Hosted Zone | string | `""` | no |
 | ip\_whitelist | IP Addresses allowed to access the ElasticSearch Cluster.  Should be supplied if Elasticsearch cluster is not VPC enabled. | list | `<list>` | no |
 | logging\_application\_logs | A boolean value to determine if logging is enabled for ES_APPLICATION_LOGS. | string | `"false"` | no |
 | logging\_index\_slow\_logs | A boolean value to determine if logging is enabled for INDEX_SLOW_LOGS. | string | `"false"` | no |

--- a/examples/basic_internet_endpoint.tf
+++ b/examples/basic_internet_endpoint.tf
@@ -3,7 +3,7 @@
 ####################################################
 
 module "es_internet" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.5"
 
   name         = "es-internet-endpoint"
   ip_whitelist = ["1.2.3.4"]

--- a/examples/basic_vpc_endpoint.tf
+++ b/examples/basic_vpc_endpoint.tf
@@ -3,7 +3,7 @@
 ###############################################
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.6"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=v0.0.7"
 
   vpc_name = "Test1VPC"
 }
@@ -16,7 +16,7 @@ module "sg" {
 }
 
 module "es_vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.5"
 
   name = "es-vpc-endpoint"
 

--- a/examples/full_example.tf
+++ b/examples/full_example.tf
@@ -7,7 +7,7 @@ data "aws_kms_alias" "es_kms" {
 }
 
 module "internal_zone" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v.0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone//?ref=v.0.0.3"
 
   zone_name     = "mycompany.local"
   environment   = "Development"
@@ -15,7 +15,7 @@ module "internal_zone" {
 }
 
 module "es_all_options" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.5"
 
   name = "es-custom"
 
@@ -37,6 +37,7 @@ module "es_all_options" {
   ebs_type = "io1"
 
   internal_record_name = "es-custom"
+  internal_zone_id     = "${module.internal_zone.internal_hosted_name}"
   internal_zone_name   = "${module.internal_zone.internal_hosted_name}"
 
   logging_application_logs = true

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -80,6 +80,7 @@ module "es_all_options" {
   ebs_type = "io1"
 
   internal_record_name = "es-custom"
+  internal_zone_id     = "${module.internal_zone.internal_hosted_zone_id}"
   internal_zone_name   = "${module.internal_zone.internal_hosted_name}"
 
   logging_application_logs = true

--- a/variables.tf
+++ b/variables.tf
@@ -64,13 +64,19 @@ variable "environment" {
 }
 
 variable "internal_record_name" {
-  description = "Record Name for the new Resource Record in the Internal Hosted Zone. i.e. es"
+  description = "Record Name for the new Resource Record in the Internal Hosted Zone"
+  type        = "string"
+  default     = ""
+}
+
+variable "internal_zone_id" {
+  description = "The Route53 Internal Hosted Zone ID"
   type        = "string"
   default     = ""
 }
 
 variable "internal_zone_name" {
-  description = "TLD for Internal Hosted Zone. i.e. mycompany.local"
+  description = "TLD for Internal Hosted Zone"
   type        = "string"
   default     = ""
 }


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):

N/A

##### Summary of change(s):

As per https://github.com/rackspace-infrastructure-automation/aws-terraform-rds/pull/18 this is moving away from a data object for R53 zone information to passing in all info as vars.

Aside from the information in the RDS PR, issue with the particular implementation that was present prior to this ES update was that the lookup was being done on a global service with the piece of information being used had no guarantee of being unique.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes

##### Do examples need to be updated based on changes?

Done

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.