### PR TITLE
Enable 3 AZ implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module creates an ElasticSearch cluster.
 
 ```HCL
 module "elasticsearch" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.5"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.7"
 
   name          = "es-internet-endpoint"
   ip_whitelist  = ["1.2.3.4"]
@@ -19,7 +19,7 @@ module "elasticsearch" {
 
 ```HCL
 module "elasticsearch" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.5"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.7"
 
   name            = "es-vpc-endpoint"
   vpc_enabled     = true
@@ -48,12 +48,12 @@ Terraform does not create the IAM Service Linked Role for ElasticSearch automati
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | create\_service\_linked\_role | A boolean value to determine if the ElasticSearch Service Linked Role should be created.  This should only be set to true if the Service Linked Role is not already present. | string | `"false"` | no |
-| data\_node\_count | Number of data nodes in the Elasticsearch cluster. If using Zone Awareness this must be an even number. | string | `"6"` | no |
-| data\_node\_instance\_type | Select data node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types. | string | `"m4.large.elasticsearch"` | no |
+| data\_node\_count | Number of data nodes in the Elasticsearch cluster. If using Zone Awareness this must be a multiple of the number of subnets being used, e.g. 2, 4, 6, etc. for 2 subnets or 3, 6, 9, etc. for 3 subnets. | string | `"6"` | no |
+| data\_node\_instance\_type | Select data node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types. | string | `"m5.large.elasticsearch"` | no |
 | ebs\_iops | The number of I/O operations per second (IOPS) that the volume supports. | string | `"0"` | no |
-| ebs\_size | The size of the EBS volume for each data node. | string | `"20"` | no |
+| ebs\_size | The size of the EBS volume for each data node. | string | `"35"` | no |
 | ebs\_type | The EBS volume type to use with the Amazon ES domain, such as standard, gp2, or io1. | string | `"gp2"` | no |
-| elasticsearch\_version | Elasticsearch Version. | string | `"6.3"` | no |
+| elasticsearch\_version | Elasticsearch Version. | string | `"7.1"` | no |
 | encrypt\_storage\_enabled | A boolean value to determine if encryption at rest is enabled for the Elasticsearch cluster. Version must be at least 5.1. | string | `"false"` | no |
 | encrypt\_traffic\_enabled | A boolean value to determine if encryption for node-to-node traffic is enabled for the Elasticsearch cluster. Version must be at least 6.0. | string | `"false"` | no |
 | encryption\_kms\_key | The KMS key to use for encryption at rest on the Elasticsearch cluster.If omitted and encryption at rest is enabled, the aws/es KMS key is used. | string | `""` | no |
@@ -67,7 +67,7 @@ Terraform does not create the IAM Service Linked Role for ElasticSearch automati
 | logging\_retention | The number of days to retain Cloudwatch Logs for the Elasticsearch cluster. | string | `"30"` | no |
 | logging\_search\_slow\_logs | A boolean value to determine if logging is enabled for SEARCH_SLOW_LOGS. | string | `"false"` | no |
 | master\_node\_count | Number of master nodes in the Elasticsearch cluster.  Allowed values are 0, 3 or 5. | string | `"3"` | no |
-| master\_node\_instance\_type | Select master node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types. | string | `"m4.large.elasticsearch"` | no |
+| master\_node\_instance\_type | Select master node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types. | string | `"m5.large.elasticsearch"` | no |
 | name | The desired name for the Elasticsearch domain. | string | n/a | yes |
 | security\_groups | A list of EC2 security groups to assign to the Elasticsearch cluster.  Ignored if Elasticsearch cluster is not VPC enabled. | list | `<list>` | no |
 | snapshot\_start\_hour | The hour (0-23) to issue a daily snapshot of Elasticsearch cluster. | string | `"0"` | no |

--- a/examples/basic_internet_endpoint.tf
+++ b/examples/basic_internet_endpoint.tf
@@ -3,7 +3,7 @@
 ####################################################
 
 module "es_internet" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.6"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.7"
 
   name         = "es-internet-endpoint"
   ip_whitelist = ["1.2.3.4"]

--- a/examples/basic_vpc_endpoint.tf
+++ b/examples/basic_vpc_endpoint.tf
@@ -16,7 +16,7 @@ module "sg" {
 }
 
 module "es_vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.6"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.7"
 
   name = "es-vpc-endpoint"
 

--- a/examples/full_example.tf
+++ b/examples/full_example.tf
@@ -15,13 +15,13 @@ module "internal_zone" {
 }
 
 module "es_all_options" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.6"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.7"
 
   name = "es-custom"
 
   ip_whitelist = ["1.2.3.4"]
 
-  elasticsearch_version = "6.2"
+  elasticsearch_version = "7.1"
   environment           = "Production"
 
   data_node_count           = "8"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *
  * ```HCL
  * module "elasticsearch" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.5"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.7"
  *
  *   name          = "es-internet-endpoint"
  *   ip_whitelist  = ["1.2.3.4"]
@@ -20,7 +20,7 @@
  *
  * ```HCL
  * module "elasticsearch" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.5"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-elasticsearch//?ref=v0.0.7"
  *
  *   name            = "es-vpc-endpoint"
  *   vpc_enabled     = true
@@ -77,6 +77,8 @@ locals {
 
   vpc_lookup     = "${var.vpc_enabled ? "vpc" : "standard"}"
   enable_logging = "${var.logging_application_logs || var.logging_index_slow_logs || var.logging_search_slow_logs}"
+
+  za_subnet_count = "${length(var.subnets) >= 3 ? 3 : 2}"
 }
 
 data "aws_region" "current" {}
@@ -158,6 +160,10 @@ resource "aws_elasticsearch_domain" "es" {
     instance_count           = "${var.data_node_count}"
     instance_type            = "${var.data_node_instance_type}"
     zone_awareness_enabled   = "${var.zone_awareness_enabled}"
+
+    zone_awareness_config {
+      availability_zone_count = "${var.zone_awareness_enabled == "false" ? 2 : local.za_subnet_count}"
+    }
   }
 
   ebs_options {

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -1,6 +1,14 @@
 provider "aws" {
-  version = "~> 1.2"
+  version = "~> 2.2"
   region  = "us-west-2"
+}
+
+resource "random_string" "r_string" {
+  length  = 6
+  special = false
+  lower   = true
+  upper   = false
+  number  = false
 }
 
 ####################################################
@@ -10,87 +18,6 @@ provider "aws" {
 module "es_internet" {
   source = "../../module"
 
-  name         = "es-internet-endpoint"
+  name         = "es-internet-endpoint-${random_string.r_string.result}"
   ip_whitelist = ["1.2.3.4"]
-}
-
-###############################################
-# Basic VPC accessible Elasticsearch endpoint #
-###############################################
-
-module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"
-
-  vpc_name = "Test1VPC"
-}
-
-module "sg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=master"
-
-  resource_name = "Test-SG"
-  vpc_id        = "${module.vpc.vpc_id}"
-}
-
-module "es_vpc" {
-  source = "../../module"
-
-  name = "es-vpc-endpoint"
-
-  vpc_enabled     = true
-  security_groups = ["${module.sg.public_web_security_group_id}"]
-  subnets         = ["${module.vpc.private_subnets}"]
-}
-
-#########################################################
-# Customized Internet accessible Elasticsearch endpoint #
-#########################################################
-
-data "aws_kms_alias" "es_kms" {
-  name = "alias/aws/es"
-}
-
-module "internal_zone" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone?ref=master"
-
-  zone_name     = "mycompany.local"
-  environment   = "Development"
-  target_vpc_id = "${module.vpc.vpc_id}"
-}
-
-module "es_all_options" {
-  source = "../../module"
-
-  name = "es-custom"
-
-  ip_whitelist = ["1.2.3.4"]
-
-  elasticsearch_version = "6.2"
-  environment           = "Production"
-
-  data_node_count           = "8"
-  data_node_instance_type   = "r4.large.elasticsearch"
-  master_node_count         = "5"
-  master_node_instance_type = "r4.large.elasticsearch"
-
-  encrypt_storage_enabled = true
-  encrypt_traffic_enabled = true
-  encryption_kms_key      = "${data.aws_kms_alias.es_kms.target_key_arn}"
-
-  ebs_iops = "1000"
-  ebs_size = "50"
-  ebs_type = "io1"
-
-  internal_record_name = "es-custom"
-  internal_zone_id     = "${module.internal_zone.internal_hosted_zone_id}"
-  internal_zone_name   = "${module.internal_zone.internal_hosted_name}"
-
-  logging_application_logs = true
-  logging_index_slow_logs  = true
-  logging_retention        = 14
-  logging_search_slow_logs = true
-
-  tags = {
-    Tag1 = "Value1"
-    Tag2 = "Value2"
-  }
 }

--- a/tests/test2/main.tf
+++ b/tests/test2/main.tf
@@ -1,0 +1,94 @@
+provider "aws" {
+  version = "~> 2.2"
+  region  = "us-west-2"
+}
+
+resource "random_string" "r_string" {
+  length  = 6
+  special = false
+  lower   = true
+  upper   = false
+  number  = false
+}
+
+module "vpc" {
+  source   = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"
+  az_count = "3"
+  vpc_name = "ES-VPC-${random_string.r_string.result}"
+}
+
+module "sg" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=master"
+
+  resource_name = "ES-VPC-SG-${random_string.r_string.result}"
+  vpc_id        = "${module.vpc.vpc_id}"
+}
+
+####################################################
+# Basic VPC 3 AZ accessible Elasticsearch endpoint #
+####################################################
+
+module "es_vpc" {
+  source = "../../module"
+
+  name = "es-vpc-endpoint-${random_string.r_string.result}"
+
+  vpc_enabled     = true
+  security_groups = ["${module.sg.public_web_security_group_id}"]
+  subnets         = ["${module.vpc.private_subnets}"]
+}
+
+#############################################
+# Customized VPC 3AZ Elasticsearch endpoint #
+#############################################
+
+data "aws_kms_alias" "es_kms" {
+  name = "alias/aws/es"
+}
+
+module "internal_zone" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-route53_internal_zone?ref=master"
+
+  zone_name     = "mycompany-${random_string.r_string.result}.local"
+  environment   = "Development"
+  target_vpc_id = "${module.vpc.vpc_id}"
+}
+
+module "es_all_options" {
+  source = "../../module"
+
+  name = "es-custom3az-${random_string.r_string.result}"
+
+  ip_whitelist = ["1.2.3.4"]
+
+  elasticsearch_version = "7.1"
+  environment           = "Development"
+  subnets               = ["${module.vpc.private_subnets}"]
+
+  data_node_count           = "6"
+  data_node_instance_type   = "m5.large.elasticsearch"
+  master_node_count         = "3"
+  master_node_instance_type = "m5.large.elasticsearch"
+
+  encrypt_storage_enabled = true
+  encrypt_traffic_enabled = true
+  encryption_kms_key      = "${data.aws_kms_alias.es_kms.target_key_arn}"
+
+  ebs_iops = "1000"
+  ebs_size = "35"
+  ebs_type = "io1"
+
+  internal_record_name = "es-custom"
+  internal_zone_id     = "${module.internal_zone.internal_hosted_zone_id}"
+  internal_zone_name   = "${module.internal_zone.internal_hosted_name}"
+
+  logging_application_logs = true
+  logging_index_slow_logs  = true
+  logging_retention        = 7
+  logging_search_slow_logs = true
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "create_service_linked_role" {
 }
 
 variable "data_node_count" {
-  description = "Number of data nodes in the Elasticsearch cluster. If using Zone Awareness this must be an even number."
+  description = "Number of data nodes in the Elasticsearch cluster. If using Zone Awareness this must be a multiple of the number of subnets being used, e.g. 2, 4, 6, etc. for 2 subnets or 3, 6, 9, etc. for 3 subnets."
   type        = "string"
   default     = 6
 }
@@ -18,7 +18,7 @@ variable "data_node_count" {
 variable "data_node_instance_type" {
   description = "Select data node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types."
   type        = "string"
-  default     = "m4.large.elasticsearch"
+  default     = "m5.large.elasticsearch"
 }
 
 variable "ebs_iops" {
@@ -30,7 +30,7 @@ variable "ebs_iops" {
 variable "ebs_size" {
   description = "The size of the EBS volume for each data node."
   type        = "string"
-  default     = 20
+  default     = 35
 }
 
 variable "ebs_type" {
@@ -42,7 +42,7 @@ variable "ebs_type" {
 variable "elasticsearch_version" {
   description = "Elasticsearch Version."
   type        = "string"
-  default     = "6.3"
+  default     = "7.1"
 }
 
 variable "encrypt_storage_enabled" {
@@ -126,7 +126,7 @@ variable "master_node_count" {
 variable "master_node_instance_type" {
   description = "Select master node instance type.  See https://aws.amazon.com/elasticsearch-service/pricing/ for supported instance types."
   type        = "string"
-  default     = "m4.large.elasticsearch"
+  default     = "m5.large.elasticsearch"
 }
 
 variable "security_groups" {


### PR DESCRIPTION
##### Corresponding Issue(s):
<!--- - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section --->

https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/261

##### Summary of change(s):

- use Zone Awareness for 3 AZ implementation
- update data node count var for this use case
- bump tag refs to future version

##### Reason for Change(s):

<!--- - If a bug, describe error scenario, including expected behavior and actual behavior. --->

<!--- - If an enhancement, describe the use case and the perceived benefit(s). --->

Enhancement: new feature - https://aws.amazon.com/about-aws/whats-new/2019/02/amazon-elasticsearch-service-now-supports-three-availability-zone-deployments/

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

Done

##### Do examples need to be updated based on changes?

No

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
